### PR TITLE
new style of past dates

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -112,6 +112,10 @@ a:hover small {
   margin:0 auto;
 }
 
+.past {
+  color: lightgray;
+}
+
 blockquote {
   border-left:1px solid #e5e5e5;
   margin:0;


### PR DESCRIPTION
Using .past for past dates on the side bar.
When I saw the call for paper with the stroke through date, I thought "oh weird the deadline is already past".
I imagine it will improve a bit readability.
We could also remove the call for paper date in the HTML file, I guess nobody really cares about this.
